### PR TITLE
FIx compilation errors

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,4 +1,5 @@
 iced = require 'iced-coffee-script'
+sysPath = require 'path'
 
 # Example
 # 

--- a/vendor/iced-coffee-script.js
+++ b/vendor/iced-coffee-script.js
@@ -1,0 +1,40 @@
+(this.require.define({
+  "iced-coffee-script": function(exports, require, module) {
+    exports.iced = {
+    Deferrals: (function() {
+
+      function _Class(_arg) {
+        this.continuation = _arg;
+        this.count = 1;
+        this.ret = null;
+      }
+
+      _Class.prototype._fulfill = function() {
+        if (!--this.count) return this.continuation(this.ret);
+      };
+
+      _Class.prototype.defer = function(defer_params) {
+        var _this = this;
+        ++this.count;
+        return function() {
+          var inner_params, _ref;
+          inner_params = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+          if (defer_params != null) {
+            if ((_ref = defer_params.assign_fn) != null) {
+              _ref.apply(null, inner_params);
+            }
+          }
+          return _this._fulfill();
+        };
+      };
+
+      return _Class;
+
+    })(),
+    findDeferral: function() {
+      return null;
+    }
+  };
+
+  }
+}));


### PR DESCRIPTION
The module was failing to compile due to an undefined sysPath and a runtime file referenced but not included in the repository. I generated the runtime by running `iced --runtime inline` and included it in a brunch-compatible format.
